### PR TITLE
Allow 'wheel' in transitive dependencies

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -23,6 +23,9 @@ in filterValid {
   "pip" = super."pip".overrideDerivation
     (old: { pipInstallFlags = [ "--ignore-installed" ]; });
 
+  "wheel" = super."wheel".overrideDerivation
+    (old: { pipInstallFlags = [ "--ignore-installed" ]; });
+
   "zipp" = super."zipp".overrideDerivation
     (old: { buildInputs = old.buildInputs ++ [ self."toml" ]; });
 }


### PR DESCRIPTION
A few days ago I ran into an error that looked very similar to nix-community/pypi2nix#371 (related: #12). I am not very familiar with pypi2nix or pypi2nix-overrides, but some poking around led me to this solution which seemed to fix things.

My reasoning was that `pypi2nix_bootstrap` depends on setuptools, pip, and wheel, but only setuptools and pip had an entry in this overrides.nix file to include this `--ignore-installed` flag. Including the same thing for wheel got me past that error. I don't know if this has other unwanted implications.